### PR TITLE
enemy: fix: 적 출력 버그 수정#65

### DIFF
--- a/src/enemy.c
+++ b/src/enemy.c
@@ -168,7 +168,7 @@ void drawEnemy() {
 
     for (int i = 0; i < MAX_ENEMIES; i++) {
         if (enemies[i].active) {
-            if (enemies->type == 0) {
+            if (enemies[i].type == 0) {
                 map[enemies[i].y][enemies[i].x] = '@';
             }
             else {


### PR DESCRIPTION
# 작업 내용
 - enemy.c
적 출력이 이상하게 되는 버그 수정
ex) @로 나와야하는데 o로 나옴
